### PR TITLE
Fixing issue where public method is set to private

### DIFF
--- a/lib/newrelic-roda/instrument.rb
+++ b/lib/newrelic-roda/instrument.rb
@@ -14,8 +14,6 @@ module NewRelic
           include ::NewRelic::Agent::MethodTracer
           add_method_tracer :match_all
 
-          private
-
           def if_match(args, &block)
             instrumented = proc do |*captures|
               params = { env.fetch('new_relic.roda').last => captures }
@@ -61,6 +59,7 @@ module NewRelic
             super
           rescue => error
             ::NewRelic::Agent.notice_error(error)
+
             raise error
           end
 

--- a/lib/newrelic-roda/version.rb
+++ b/lib/newrelic-roda/version.rb
@@ -1,5 +1,5 @@
 module NewRelic
   module Roda
-    VERSION = '1.0.0.pre1'
+    VERSION = '1.0.0.pre2'
   end
 end


### PR DESCRIPTION
Whenever I was getting a request like "//hello" with two slashes I would get the exception

```
2015-01-14T19:56:00.394944+00:00 app[web.1]: 2015-01-14 19:56:00 +0000: Rack app error: #<NoMethodError: private method `block_result' called for #<App::RodaRequest GET //>>
2015-01-14T19:56:00.394958+00:00 app[web.1]: /app/vendor/bundle/ruby/2.1.0/gems/roda-1.3.0/lib/roda.rb:346:in `block in _route'
2015-01-14T19:56:00.394960+00:00 app[web.1]: /app/vendor/bundle/ruby/2.1.0/gems/roda-1.3.0/lib/roda.rb:344:in `catch'
2015-01-14T19:56:00.394963+00:00 app[web.1]: /app/vendor/bundle/ruby/2.1.0/gems/newrelic-roda-1.0.0.pre1/lib/newrelic-roda/instrument.rb:70:in `block in _route'
2015-01-14T19:56:00.394961+00:00 app[web.1]: /app/vendor/bundle/ruby/2.1.0/gems/roda-1.3.0/lib/roda.rb:344:in `_route'
2015-01-14T19:56:00.394965+00:00 app[web.1]: /app/vendor/bundle/ruby/2.1.0/gems/newrelic_rpm-3.9.9.275/lib/new_relic/agent/instrumentation/controller_instrumentation.rb:366:in `perform_action_with_newrelic_trace'
```

I noticed that the block is not private in roda and I made the change. It works.
